### PR TITLE
use plug._plain_dict() before returning from analyse()

### DIFF
--- a/senpy/extensions.py
+++ b/senpy/extensions.py
@@ -103,7 +103,7 @@ class Senpy(object):
         nif_params.update(specific_params)
         try:
             resp = plug.analyse(**nif_params)
-            resp.analysis.append(plug)
+            resp.analysis.append(plug._plain_dict())
             logger.debug("Returning analysis result: {}".format(resp))
         except Exception as ex:
             resp = Error(message=str(ex), status=500)


### PR DESCRIPTION
We're experiencing significant delays when we have large objects as plugin instance variables. This edit seems to fix the problem. I also tried making the large objects into class variables, but the problem was not solved :(

It looks like the plugin instance is passed (inside the response object) as-is to flask: perhaps flask is walking through it or duplicating it in memory or some such? Not sure...

There may be a better way?

(and can we assume the plugin has a _plain_dict() method?)