### PR TITLE
add make version to readme for pip install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,8 @@ Through PIP
 
 .. code:: bash
 
-   pip install --user senpy
+   make version
+   pip install -U --user senpy
 
    
 Alternatively, you can use the development version:


### PR DESCRIPTION
pip install needs the VERSION file - `make version` will create that file

I also added the -U flag to pip install to force install (this is important if the user is playing with the code or trying out different older versions, as pip will not install if it thinks the git repo represents a version already installed or older than the one installed)