### PR TITLE
removed broken-ish "/api" link in index.html

### DIFF
--- a/senpy/templates/index.html
+++ b/senpy/templates/index.html
@@ -47,7 +47,7 @@
                     This website is the senpy Playground, which allows you to test the instance of senpy in this server. It provides a user-friendly interface to the functions exposed by the senpy API.
                     </p>
                   <p>
-                    Once you get comfortable with the parameters and results, you are encouraged to issue your own requests to the API endpoint, which should be <a href="/api">here</a>.
+                    Once you get comfortable with the parameters and results, you are encouraged to issue your own requests to the API endpoint. You can find examples of api url's when you try out a plugin with the "Analyse!" button ont he "Test it" tab.
                   </p>
                   <p>
                     These are some of the things you can do with the API:


### PR DESCRIPTION
In index.html, there is a suggestion to try out the api with a link to "/api". Clicking that link results in a json error report - not ideal. 
Instead, I added text suggesting that a use can find example api url's after clickgin "Analyse!".