### PR TITLE
update deprecated pip --use-wheel

### DIFF
--- a/senpy/extensions.py
+++ b/senpy/extensions.py
@@ -334,7 +334,8 @@ class Senpy(object):
         if requirements:
             pip_args = []
             pip_args.append('install')
-            pip_args.append('--use-wheel')
+            pip_args.append('--only-binary')
+            pip_args.append(':all:')
             for req in requirements:
                 pip_args.append(req)
             logger.info('Installing requirements: ' + str(requirements))


### PR DESCRIPTION
--use-wheel is deprecated in favour of --only-binary and is currently not present in pip master branch (with an added option :all: which could specify particular packages).
--only-binary has been around since pip 7 or so.