### PR TITLE
changed pip call to avoid logger config code in pip 

### DIFF
--- a/senpy/extensions.py
+++ b/senpy/extensions.py
@@ -338,7 +338,11 @@ class Senpy(object):
             for req in requirements:
                 pip_args.append(req)
             logger.info('Installing requirements: ' + str(requirements))
-            pip.main(pip_args)
+
+            cmd_name, cmd_args = pip.parseopts(pip_args)
+            command = pip.commands_dict[cmd_name](isolated=pip.check_isolated(cmd_args))
+            options, args = command.parse_args(cmd_args)
+            command.run(options, args)
 
     @classmethod
     def _load_module(cls, name, root):


### PR DESCRIPTION
this may not be resilient to change in pip, but works for 9.0.1 and the master branch of pip

The new code is basically copied from  [pip.basecommand.Command.main()](https://github.com/pypa/pip/blob/master/pip/basecommand.py#L105). This is the method that gets called by pip.main(), and it basically sets up the logger config (which we don't want), then executes these commands. There are a [couple other environment variable checks](https://github.com/pypa/pip/blob/master/pip/basecommand.py#L199) also, but they seem unnecessary and even more subject to change.

This is a proof-of-concept for fixing pip's screwing with logging #23. I haven't looked at different versions of pip much, just 9.0.1 (current) and 10.0.0 (dev version, HEAD of repo). If we want to go this way, we should check other versions better. Also, I've only worked in python 3.5 here.