### PR TITLE
Estimate VAD by weighted average

### DIFF
--- a/senpy/plugins/conversion/centroids.py
+++ b/senpy/plugins/conversion/centroids.py
@@ -35,17 +35,20 @@ class CentroidConversion(EmotionConversionPlugin):
         super(CentroidConversion, self).__init__(info)
 
     def _forward_conversion(self, original):
-        """Sum the VAD value of all categories found weighted by intensity. """
+        """Sum the VAD value of all categories found weighted by intensity. 
+        Intensities are scaled by onyx:maxIntensityValue if it is present, else maxIntensityValue is assumed to be one.
+        Emotion entries that do not have onxy:hasEmotionIntensity specified are assumed to have maxIntensityValue.
+        Emotion entries that do not have onyx:hasEmotionCategory specified are ignored."""
         res = Emotion()
         maxIntensity = float(original.get("onyx__maxIntensityValue",1))
-        sumIntensities = 0
         neutralPoint = self.get("origin",None)
         for e in original.onyx__hasEmotion:
-            category = e.onyx__hasEmotionCategory
+            category = e.get("onyx__hasEmotionCategory", None)
+            if category is None: 
+                continue
             intensity = e.get("onyx__hasEmotionIntensity",maxIntensity)/maxIntensity
             if intensity == 0:
                 continue
-            sumIntensities += intensity
             centoid = self.centroids.get(category,None)
             if centroid:
                 for dim, value in centroid.items():

--- a/senpy/plugins/conversion/centroids.py
+++ b/senpy/plugins/conversion/centroids.py
@@ -42,18 +42,19 @@ class CentroidConversion(EmotionConversionPlugin):
         for e in original.onyx__hasEmotion:
             category = e.onyx__hasEmotionCategory
             intensity = e.get("onyx__hasEmotionIntensity",1)
+            if intensity == 0:
+                continue
             if category in self.centroids:
-                totalIntensities[category] += intensity
                 for dim, value in self.centroids[category].items():
+                    totalIntensities[dim] += intensity
                     try:
                         res[dim] += value * intensity
                     except Exception:
                         res[dim] = value * intensity
+
         for dim,intensity in totalIntensities.items():
             if intensity != 0:
                 res[dim] /= intensity
-            else:
-                res[dim] = self.centroids.get('neutral', {dim:0})[dim]
         return res
 
     def _backwards_conversion(self, original):

--- a/senpy/plugins/conversion/centroids.py
+++ b/senpy/plugins/conversion/centroids.py
@@ -49,7 +49,7 @@ class CentroidConversion(EmotionConversionPlugin):
                     totalIntensities[dim] += intensity
                     try:
                         res[dim] += value * intensity
-                    except Exception:
+                    except KeyError:
                         res[dim] = value * intensity
 
         for dim,intensity in totalIntensities.items():

--- a/senpy/plugins/conversion/centroids.py
+++ b/senpy/plugins/conversion/centroids.py
@@ -1,6 +1,5 @@
 from senpy.plugins import EmotionConversionPlugin
 from senpy.models import EmotionSet, Emotion, Error
-from collections import defaultdict
 
 import logging
 logger = logging.getLogger(__name__)

--- a/senpy/plugins/conversion/emotion/ekman2vad.senpy
+++ b/senpy/plugins/conversion/emotion/ekman2vad.senpy
@@ -30,10 +30,6 @@ centroids:
     A: 5.21
     D: 2.82
     V: 2.21
-  neutral:
-    A: 5.00
-    D: 2.00
-    V: 5.00
 centroids_direction:
   - emoml:big6
   - emoml:pad

--- a/senpy/plugins/conversion/emotion/ekman2vad.senpy
+++ b/senpy/plugins/conversion/emotion/ekman2vad.senpy
@@ -4,6 +4,11 @@ module: senpy.plugins.conversion.centroids
 description: Plugin to convert emotion sets from Ekman to VAD
 version: 0.1
 # No need to specify onyx:doesConversion because centroids.py adds it automatically from centroids_direction
+origin:
+  # Point in VAD space with no emotion (aka Neutral)
+  A: 5.0
+  D: 5.0
+  V: 5.0
 centroids:
   anger:
     A: 6.95
@@ -25,6 +30,10 @@ centroids:
     A: 5.21
     D: 2.82
     V: 2.21
+  neutral:
+    A: 5.00
+    D: 2.00
+    V: 5.00
 centroids_direction:
   - emoml:big6
   - emoml:pad


### PR DESCRIPTION
Does a weighted average of centroids.

If intensity sums to zero for a category, a 'neutral' category is used or 0 if it's not present. I'm not 100% sure this is the best approach, and the name of the "neutral" category perhaps should use some convention?

Note that if there are no categories present, then no VAD (or other dimensional) estimate is returned. It may be better to use the neutral centroid if it's present in this case also.