### PR TITLE
use emoionml names for fsre and pad dimensions

### DIFF
--- a/senpy/plugins/conversion/emotion/ekman2fsre.senpy
+++ b/senpy/plugins/conversion/emotion/ekman2fsre.senpy
@@ -2,38 +2,50 @@
 name: Ekman2FSRE
 module: senpy.plugins.conversion.emotion.centroids
 description: Plugin to convert emotion sets from Ekman to VAD
-version: 0.1
+version: 0.2
 # No need to specify onyx:doesConversion because centroids.py adds it automatically from centroids_direction
 centroids:
   anger:
     A: 6.95
     D: 5.1
     V: 2.7
+    S: 5.0
   disgust:
     A: 5.3
     D: 8.05
     V: 2.7
+    S: 5.0
   fear:
     A: 6.5
     D: 3.6
     V: 3.2
+    S: 5.0
   happiness:
     A: 7.22
     D: 6.28
     V: 8.6
+    S: 5.0
   sadness:
     A: 5.21
     D: 2.82
     V: 2.21
+    S: 5.0
+  surprise:
+    A: 5.0
+    D: 5.0
+    V: 5.0
+    S: 10.0
 centroids_direction:
   - emoml:big6
   - emoml:fsre-dimensions
 aliases: # These are aliases for any key in the centroid, to avoid repeating a long name several times
-  A: emoml:arousal
-  V: emoml:valence
-  D: emoml:dominance
+  A: emoml:fsre-dimensions:arousal
+  V: emoml:fsre-dimensions:valence
+  D: emoml:fsre-dimensions:potency
+  S: emoml:fsre-dimensions:unpredictability
   anger: emoml:big6anger
   disgust: emoml:big6disgust
   fear: emoml:big6fear
   happiness: emoml:big6happiness
   sadness: emoml:big6sadness
+  surprise: emoml:big6surprise


### PR DESCRIPTION
This lines up the names in the conversion plugins with the [emotionML suggested vocab](https://www.w3.org/TR/emotion-voc/#dimensions).

emoml has different names for the 4-dimensional fsre scheme and the 3-dimensional vad scheme, which this pull request has added.

I've added the "unpredictability" dimension and mapped big6:surprise to it's maximum value. The assumption is that surprise varies between 5 and 10 to be in line with the other dimensions (no such thing as negative surprise, so no values less than 5). I see that arousal also has all values >5 (so no negative arousal). Ideally, surprise mappings for V, A and D should be calculated empirically - I think there'll be some arousal and possibly slightly lowered dominance.

I wonder if we should use another colon in the emoml names, eg: "emoml:fsredim:valence" or "emoml:big6:happiness", since the [emoml suggested vocab](https://www.w3.org/TR/emotion-voc/xml) only specifies names like "happiness" in a category "big6" (ie: it's hard to know which is the category in "big6happiness").
We'd have to go through the example plugins and make sure they also conform...

open to discussion on this btw...

ps: apologies for multiple changes in this one pr..